### PR TITLE
add better debug support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,39 @@
 # deflea
 such conversion very javascript wow.
 
-### Run the app:
+## Run the app:
 `$ npm i`
 
 `$ npm run start`
 
-### Connecting deflea to a local version of dogescript
+## Connecting deflea to a local version of dogescript
 To connect a working dev version of dogescript:
+
 `npm link <PATH_TO_DOGESCRIPT>`
 
 `npm run start`
+
+### Loading Tests
+
+Import all your specs by doing `npm run import:specs` after linking your build of dogescript.
+
+e.g.:
+
+```bash
+$ npm run import:specs
+
+> debooger@1.0.0 import:specs J:\Workspaces\deflea
+> node scripts/import-specs.js --all
+
+...........................................................................
+Successfully imported 75 specs.
+```
+
+## Debugging a Test
+
+1. When the page loads, select the test you wish to debug.
+  * The *Dogescript Source* text area should load with the source code
+1. Using the *Developer Tools*
+  1. Find the dogescript parser under `webpack://` -> `dogescript/lib/parser.js`
+  1. Set your breakpoint in the `parse` function
+  1. Reload the test

--- a/scripts/import-specs.js
+++ b/scripts/import-specs.js
@@ -140,12 +140,19 @@ skywalker.on('end', function() {
     var testFile = readCleanCRLF(testFilePath);
     var source   = readCleanCRLF(sourcePath);
     const actual = dogescript(source, true);
+
+    var status = actual === testFile ? 'passed' : 'failed';
+    if(fs.existsSync(skip))
+    {
+      status='skipped';
+    }
+
     var json     = {
       name: getFolderName(dir),
       source: source,
       expected: testFile,
       actual: actual,
-      passed: actual === testFile
+      status: status
     };
 
     fObj[json.name] = json;

--- a/src/App.js
+++ b/src/App.js
@@ -28,8 +28,9 @@ export default class App extends React.Component {
           <p> type for great instant compile wow </p>
         </div>
 
-        <CodeInput onChange={this.handleChangeForDoge} />
-        <TestList show={this.state.debug} tests={testManifest} />
+        <TestList show={this.state.debug} tests={testManifest}/>
+        <CodeInput onChange={this.handleChangeForDoge} jsText={this.state.jsText} debug={this.state.debug}/>
+
       </div>
     );
   }

--- a/src/components/CodeInput.js
+++ b/src/components/CodeInput.js
@@ -35,32 +35,43 @@ export default class CodeInput extends React.Component {
 
   render() {
     return (
-      <div>
-        <div>
-          <p>Dogescript</p>
-          <p>Javascript</p>
-        </div>
-        <br /><br /> <br />
-        <div>
-          <textarea
-            style={{resize: 'none'}}
-            onChange={this.handleChangeForDoge}
-            className="dogescript"
-            defaultValue={defaultDoge}
-          />
-          <textarea
-            style={{resize: 'none'}}
-            className="javascript"
-            defaultValue={ parse(defaultDoge) }
-          />
-          { this.state.debug &&
-            <textarea
-              style={{resize: 'none'}}
-              className="javascript"
-              defaultValue={ parse(defaultDoge) }
+      <div className='code-input' style={{ float:'right', width: '75%' }} >
+          <div style={{ border: '1px solid black', width: '32%', float: 'left', marginLeft:'1%', marginBotton:'1%' }}>
+            <div style={{ textAlign: 'center', width: '100%', margin:'10px' }}>
+              <span>Dogescript Source</span>
+            </div>
+            <textarea rows='40'
+              style={{wrap: 'off',  marginLeft: '5%', width:'90%', rows:25}}
+              onChange={(e) => this.props.onChange(e)}
+              className="dogescript"
+              defaultValue={defaultDoge}
             />
+          </div>
+          { this.props.debug &&
+            <div style={{ border: '1px solid black', width: '32%', float: 'left', marginLeft:'1%', marginBotton:'1%'  }}>
+              <div style={{ textAlign: 'center', width: '100%', margin:'10px' }}>
+                  <span>Expected Javascript</span>
+              </div>
+              <textarea rows='40'
+                style={{wrap: 'off', marginLeft: '5%', width:'90%'}}
+                readOnly
+                className="expected-javascript"
+                defaultValue={ parse(defaultDoge) }
+              />
+            </div>
           }
-        </div>
+          <div style={{ border: '1px solid black', width: '32%', marginLeft:'1%', float:'left', marginBotton:'1%' }}>
+            <div style={{ textAlign: 'center', width: '100%', margin:'10px', rows:25}}>
+                <span>Actual Javascript</span>
+            </div>
+            <textarea rows='40'
+            style={{wrap: 'off',  marginLeft: '5%', width:'90%'}}
+            readOnly
+            value={this.props.jsText}
+            className="actual-javascript"
+            defaultValue= { parse(defaultDoge) }
+            />
+          </div>
       </div>
     )
   }

--- a/src/components/TestList.js
+++ b/src/components/TestList.js
@@ -18,44 +18,79 @@ export default class TestList extends React.Component {
     showPassing: true,
   }
 
+  constructor(props) {
+   super(props);
+
+   this.loadTest = this.loadTest.bind(this);
+ }
+
+  loadTest(name, test)
+  {
+    console.log('TestName:' + name);
+    console.log('Data:' + test.source);
+    let dogeArea = document.querySelector('.dogescript')
+    dogeArea.value=test.source;
+    var event = new Event('input', { bubbles: true });
+    dogeArea.dispatchEvent(event);
+    let expectedJS = document.querySelector('.expected-javascript');
+    expectedJS.value=test.expected;
+  }
+
   render() {
     const testItems = Object.entries(this.props.tests).map(([k, v]) => {
-      const className = v.passed ? 'passed' : 'failed';
+      const className = v.status;
       let icon = null;
-      if(v.passed)
+
+      switch(v.status)
       {
-        icon = <FontAwesome
+        case 'passed':
+          icon = <FontAwesome
                   name='fa-check-circle'
                   className='fa-check-circle'
                   title={className}
                   style={{
                       marginRight:'10px',
                       color:'#3b823e',
-                      fontSize:'24px'
+                      fontSize:'24px',
+                      verticalAlign:'middle'
                     }} />
-      }
-      else {
+          break;
+        case 'failed':
+          icon = <FontAwesome
+                    name='fa-times-circle'
+                    className='fa-times-circle'
+                    title={className}
+                    style={{
+                        marginRight:'10px',
+                        color:'#e23939',
+                        fontSize:'24px',
+                        verticalAlign:'middle'
+                      }} />
+          break;
+        case 'skipped':
         icon = <FontAwesome
-                  name='fa-check-circle'
+                  name='fa-exclamation-circle'
                   className='fa-exclamation-circle'
                   title={className}
                   style={{
                       marginRight:'10px',
-                      color:'red',
-                      fontSize:'24px'
+                      color:'#dcb12f',
+                      fontSize: '24px',
+                      verticalAlign:'middle'
                     }} />
+          break;
       }
 
       return (
-        <div className={ 'item ' + className } key={k}>
+        <div className={ 'item ' + className } key={k} onClick={() => this.loadTest(k,v)} style={{ margin: '2px' }}>
           {icon}
-          <span>{k}</span>
+          <span style={{ verticalAlign:'middle' }}>{k}</span>
         </div>
       )
     });
 
     return (
-      <div className='test-list'>
+      <div className='test-list' style={{ float:'left', width:'25%', background: '#dfe0e6' }}>
         {testItems}
       </div>
     )


### PR DESCRIPTION
* Changed icon colors:
  - green (passed)
  - red (failed)
  - yellow (skipped)

Which requires an update to the manifest. (From `passed` to `status`). 

* Added ability to load test code (both source and expected) into the text areas
* Updated instructions

The editor now looks like this:

![image](https://user-images.githubusercontent.com/3474369/37572954-956e2744-2ae0-11e8-931e-99e243926828.png)

Figured I should get this in before adding test highlight once you click on something. Probably will require some state keeping track off, im not the best at react.

